### PR TITLE
changed the directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ By default, the `jlpm build` command generates the source maps for this extensio
 jupyter lab build --minimize=False
 ```
 
+### Troubleshooting
+Try running `pip install jupyter_packaging`. If you are still getting a Module Not Found error for jupyter_packaging, try running the above commands with `sudo`
+
 ### Development uninstall
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `jlpm` command is JupyterLab's pinned version of
 
 ```bash
 # Clone the repo to your local environment
-# Change directory to the edsc_jupyter_extension directory
+# Change directory to the edsc-jupyter-extension directory
 # Install package in development mode
 pip install -e .
 # Link your development version of the extension with JupyterLab


### PR DESCRIPTION
The README previously said cd into `edsc_jupyter_extension` which makes it seem like you should cd into the subfolder `edsc_jupyter_extension`, but when you do you get this error message: 
```ERROR: file:///.../edsc-jupyter-extension/edsc_jupyter_extension does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.```
Therefore, I am assuming the command `pip install -e .` should be run in the root directory 